### PR TITLE
Fix selection using indexers with more than chunks

### DIFF
--- a/src/xoak/accessor.py
+++ b/src/xoak/accessor.py
@@ -185,7 +185,7 @@ class XoakAccessor:
             indices_col = da.argmin(distances, axis=1)
 
             results = da.blockwise(
-                lambda arr, icol: np.take_along_axis(arr, icol[:, None], 1),
+                lambda arr, icol: np.take_along_axis(arr, icol[:, None], 1).squeeze(),
                 'i',
                 indices,
                 'ik',


### PR DESCRIPTION
Before this PR, the `dask_support` example notebook failed with the following error message:

```
ValueError: could not broadcast input array from shape (x,1) into shape (x,)
```

with versions:

- numpy: 1.21.1
- dask: 2021.07.2
- xarray: 0.19.0

This PR fixes that.