### PR TITLE
Replace deprecated pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
 ]
 

--- a/src/xoak/__init__.py
+++ b/src/xoak/__init__.py
@@ -1,10 +1,14 @@
-from pkg_resources import DistributionNotFound, get_distribution
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    # Python < 3.8
+    from importlib_metadata import version, PackageNotFoundError
 
 from .accessor import XoakAccessor
 from .index import IndexAdapter, IndexRegistry
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # pragma: no cover
+    __version__ = version(__name__)
+except PackageNotFoundError:  # pragma: no cover
     # package is not installed
     pass


### PR DESCRIPTION
pkg_resources is deprecated in python 3.12. This pull request replaces it by importlib so it works in python3.12.